### PR TITLE
Fixed boundary error involving inventory slots

### DIFF
--- a/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
+++ b/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
@@ -625,7 +625,7 @@ public class PlayerListener implements Listener, Configurable {
 			} else {
 				// otherwise, put the prison pearl in the first empty slot
 				pearlnum = inv.firstEmpty();
-				if (pearlnum > 0) {
+				if (pearlnum >= 0) {
 					// and reduce his stack of pearls by one
 					stack.setAmount(stack.getAmount() - 1);
 					inv.setItem(stacknum, stack);
@@ -955,7 +955,7 @@ public class PlayerListener implements Listener, Configurable {
 						int openSlot = player.getInventory().firstEmpty();
 						ItemStack giveBack = repairItem.getStack().clone();
 						giveBack.setAmount(numLeft);
-						if (openSlot > 0) {
+						if (openSlot >= 0) {
 							player.getInventory().setItem(openSlot, giveBack);
 							msg(player, "<i>The remaining %d repair items were put back in your inventory.", numLeft);
 						} else {
@@ -1003,7 +1003,7 @@ public class PlayerListener implements Listener, Configurable {
 						int openSlot = player.getInventory().firstEmpty();
 						ItemStack giveBack = upgradeItem.getStack().clone();
 						giveBack.setAmount(numLeft);
-						if(openSlot > 0) {
+						if(openSlot >= 0) {
 							player.getInventory().setItem(openSlot, giveBack);
 							msg(player, "<i>The remaining %d upgrade items were put back in your inventory.", numLeft);
 						} else {


### PR DESCRIPTION
These should be `>= 0` because `> 0` means the action will never happen on the first inventory slot. If this is the intended behavior, it needs a comment stating that is the case. See [this](https://github.com/CivClassic/ExilePearl/blob/8603ab1697801e0d62c40f95d786d56ff9d3a422/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java#L437) example in the same file for how it should be done.