### PR TITLE
Fixed boundary error involving pearl costs

### DIFF
--- a/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
+++ b/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
@@ -1008,7 +1008,7 @@ public class PlayerListener implements Listener, Configurable {
 							msg(player, "<i>The remaining %d upgrade items were put back in your inventory.", numLeft);
 						} else {
 							player.getWorld().dropItemNaturally(player.getLocation().add(0, 0.5, 0), giveBack);
-							msg(player, "<i>The remaining %d repair items were dropped on the ground.", numLeft);
+							msg(player, "<i>The remaining %d upgrade items were dropped on the ground.", numLeft);
 						}
 						break;
 					}

--- a/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
+++ b/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
@@ -982,7 +982,7 @@ public class PlayerListener implements Listener, Configurable {
 		RepairMaterial upgradeItem = null;
 		
 		for(RepairMaterial item : upgradeMaterials) {
-			if(invItems.getAmount(item.getStack()) > item.getRepairAmount()) {
+			if(invItems.getAmount(item.getStack()) >= item.getRepairAmount()) {
 				upgradeItem = item;
 				break;
 			}


### PR DESCRIPTION
This should be `>=`, not `>`, and it shows up as requiring inexact change when upgrading the pearl. (ie, it doesn't work if you put only exactly the upgrade cost.