### PR TITLE
Add config option for disabling summoning

### DIFF
--- a/src/main/java/com/devotedmc/ExilePearl/Lang.java
+++ b/src/main/java/com/devotedmc/ExilePearl/Lang.java
@@ -50,5 +50,6 @@ public class Lang
 	public static final String onlyExiledPlayers = "<i>Only exiled players can do that.";
 	public static final String suicideInSeconds = "<n>You will suicide in %d seconds.";
 	public static final String suicideCancelled = "<i>Your suicide has been cancelled because you moved.";
+	public static final String summoningNotEnabled = "<b>Pearl summoning is not enabled.";
 	
 }

--- a/src/main/java/com/devotedmc/ExilePearl/Lang.java
+++ b/src/main/java/com/devotedmc/ExilePearl/Lang.java
@@ -3,7 +3,7 @@ package com.devotedmc.ExilePearl;
 public class Lang 
 {
 	public static final String pearlCantHold = "<b>Exiled players can't pick up exile pearls.";
-	public static final String pearlMotd2 = "<i>Type \"<c>/pp locate<i>\" to locate your pearl.";
+	public static final String pearlMotd2 = "<i>Type \"<c>/ep locate<i>\" to locate your pearl.";
 	public static final String pearlNotExiled = "<i>You are not exiled.";
 	public static final String pearlPearlIsHeld = "<i>Your pearl is held by <a>%s <n>[%d %d %d %s]";
 	public static final String pearlYouBound = "<g>You've bound <c>%s <g>to an exile pearl!";
@@ -18,7 +18,7 @@ public class Lang
 	public static final String pearlCantDoThat = "<i>You can't do that when exiled!";
 	public static final String pearlNoPlayer = "<i>There's no online player by that name.";
 	public static final String pearlBcastRequestSent = "<i>Broadcast request sent.";
-	public static final String pearlBcastRequest = "<c>%s <i>has requested to broadcast their pearl location.\nType <c>/ep confirm <i>to confirm";
+	public static final String pearlBcastRequest = "<c>%s <i>has requested to broadcast their pearl location.\nType <c>/ep accept <i>to accept.";
 	public static final String pearlNoBcastRequest = "<i>You have no broadcast requests.";
 	public static final String pearlGettingBcasts = "<g>You have now receiving broadcasts from <c>%s";
 	public static final String pearlNotGettingBcasts = "<i>You aren't getting broadcasts from <c>%s";
@@ -29,6 +29,7 @@ public class Lang
 	public static final String pearlCantThrow = "<i>You can't throw exile pearls.";
 	public static final String pearlCantSummon = "<i>That pearl can't be summoned.";
 	public static final String pearlSummoned = "<g>You have summoned <c>%s<g>!";
+	public static final String pearlYouWereSummoned = "<g>You were summoned by <c>%s<g>!";
 	public static final String pearlCantReturn = "<i>That pearl can't be returned.";
 	public static final String pearlReturned = "<g>You have returned <c>%s<g>!";
 	
@@ -48,8 +49,11 @@ public class Lang
 	public static final String locNotInventory = "<i>That location isn't an inventory.";
 	public static final String ruleCantDoThat = "<i>You can't %s when you are exiled.";
 	public static final String onlyExiledPlayers = "<i>Only exiled players can do that.";
+	public static final String onlyPrisonedPlayers = "<b>Only prison pearled players can do that.";
 	public static final String suicideInSeconds = "<n>You will suicide in %d seconds.";
 	public static final String suicideCancelled = "<i>Your suicide has been cancelled because you moved.";
 	public static final String summoningNotEnabled = "<b>Pearl summoning is not enabled.";
-	
+	public static final String summonRequested = "<i>You have requested to summon <c>%s<i>.";
+	public static final String hasRequestedToSummon = "<c>%s <i>has requested to summon you.\nType <c>/ep confirm <i>to agree.";
+	public static final String noSummonRequested = "<b>No summon was requested.";
 }

--- a/src/main/java/com/devotedmc/ExilePearl/PearlManager.java
+++ b/src/main/java/com/devotedmc/ExilePearl/PearlManager.java
@@ -13,7 +13,7 @@ public interface PearlManager extends PearlAccess {
 	 * Performs a health decay operation on all pearls
 	 */
 	void decayPearls();
-	
+
 	/**
 	 * Adds a pearl broadcast request for a player
 	 * @param player The player requested
@@ -33,4 +33,18 @@ public interface PearlManager extends PearlAccess {
 	 * @param player The player to remove
 	 */
 	void removeBroadcastRequest(Player player);
+
+	/**
+	 * Requests the player in the pearl to be summoned
+	 * @param summoner The player requesting the summon
+	 * @param pearl The pearl instance
+	 */
+	void requestSummon(Player summoner,ExilePearl pearl);
+	
+	/**
+	 * Checks if the given pearl has been requested to summon
+	 * @param pearl The pearl instance
+	 * @return The player that summoned the pearl, or null for no summon requested
+	 */
+	Player getSummoner(ExilePearl pearl);
 }

--- a/src/main/java/com/devotedmc/ExilePearl/command/CmdExilePearl.java
+++ b/src/main/java/com/devotedmc/ExilePearl/command/CmdExilePearl.java
@@ -37,6 +37,7 @@ public class CmdExilePearl extends PearlCommand {
 		addSubCommand(cmdBcastConfirm);
 		addSubCommand(cmdBcastSilence);
 		addSubCommand(new CmdSummon(plugin));
+		addSubCommand(new CmdSummonConfirm(plugin));
 		addSubCommand(new CmdReturn(plugin));
 		
 		// Admin commands

--- a/src/main/java/com/devotedmc/ExilePearl/command/CmdPearlBroadcastConfirm.java
+++ b/src/main/java/com/devotedmc/ExilePearl/command/CmdPearlBroadcastConfirm.java
@@ -9,10 +9,10 @@ public class CmdPearlBroadcastConfirm extends PearlCommand {
 
 	public CmdPearlBroadcastConfirm(ExilePearlApi pearlApi) {
 		super(pearlApi);
-		this.aliases.add("confirm");
+		this.aliases.add("accept");
 
 		this.senderMustBePlayer = true;
-		this.setHelpShort("Confirms a pearl broadcast request.");
+		this.setHelpShort("Accept a pearl broadcast request.");
 	}
 
 	@Override

--- a/src/main/java/com/devotedmc/ExilePearl/command/CmdSummon.java
+++ b/src/main/java/com/devotedmc/ExilePearl/command/CmdSummon.java
@@ -3,6 +3,7 @@ package com.devotedmc.ExilePearl.command;
 import com.devotedmc.ExilePearl.ExilePearl;
 import com.devotedmc.ExilePearl.ExilePearlApi;
 import com.devotedmc.ExilePearl.Lang;
+import com.devotedmc.ExilePearl.PearlType;
 
 public class CmdSummon extends PearlCommand {
 
@@ -26,12 +27,16 @@ public class CmdSummon extends PearlCommand {
 			msg(Lang.pearlMustBeHoldingPearl);
 			return;
 		}
-
-
-		if(plugin.summonPearl(pearl, player())) {
-			msg(Lang.pearlSummoned, pearl.getPlayerName());
-		} else {
-			msg(Lang.pearlCantSummon);
+		if (pearl.getPearlType() != PearlType.PRISON) {
+			msg("<b>You can only do that with prion pearls.");
+			return;
 		}
+		if(pearl.getPlayer() == null) {
+			msg("<b>That player is offline, and can't be summoned.");
+			return;
+		}
+		plugin.getPearlManager().requestSummon(player(),pearl);
+		msg(Lang.summonRequested,pearl.getPlayerName());
+		msg(pearl.getPlayer(),Lang.hasRequestedToSummon,player().getName());
 	}
 }

--- a/src/main/java/com/devotedmc/ExilePearl/command/CmdSummon.java
+++ b/src/main/java/com/devotedmc/ExilePearl/command/CmdSummon.java
@@ -31,7 +31,7 @@ public class CmdSummon extends PearlCommand {
 			msg("<b>You can only do that with prion pearls.");
 			return;
 		}
-		if(pearl.getPlayer() == null) {
+		if(pearl.getPlayer() == null || !pearl.getPlayer().isOnline()) {
 			msg("<b>That player is offline, and can't be summoned.");
 			return;
 		}

--- a/src/main/java/com/devotedmc/ExilePearl/command/CmdSummon.java
+++ b/src/main/java/com/devotedmc/ExilePearl/command/CmdSummon.java
@@ -16,11 +16,17 @@ public class CmdSummon extends PearlCommand {
 	
 	@Override
 	public void perform() {
+		if(!plugin.getPearlConfig().allowSummoning()) {
+			msg(Lang.summoningNotEnabled);
+			return;
+		}
+
 		ExilePearl pearl = plugin.getPearlFromItemStack(player().getInventory().getItemInMainHand());
 		if(pearl == null) {
 			msg(Lang.pearlMustBeHoldingPearl);
 			return;
 		}
+
 
 		if(plugin.summonPearl(pearl, player())) {
 			msg(Lang.pearlSummoned, pearl.getPlayerName());

--- a/src/main/java/com/devotedmc/ExilePearl/command/CmdSummonConfirm.java
+++ b/src/main/java/com/devotedmc/ExilePearl/command/CmdSummonConfirm.java
@@ -33,14 +33,20 @@ public class CmdSummonConfirm extends PearlCommand {
 		Player summoner = plugin.getPearlManager().getSummoner(pearl);
 		if(summoner == null) {
 			msg(Lang.noSummonRequested);
+			return;
+		}
+		
+		if(!summoner.isOnline()) {
+			msg("<c>%s <b> is offline, so you couldn't be summoned.", summoner.getName());
+			return;
+		}
+		
+		if(plugin.summonPearl(pearl, summoner)) {
+			msg(summoner,Lang.pearlSummoned, pearl.getPlayerName());
+			msg(Lang.pearlYouWereSummoned, summoner.getName());
 		} else {
-			if(plugin.summonPearl(pearl, summoner)) {
-				msg(summoner,Lang.pearlSummoned, pearl.getPlayerName());
-				msg(Lang.pearlYouWereSummoned, summoner.getName());
-			} else {
-				msg(summoner,Lang.pearlCantSummon);
-				msg("<b>Summon failed.");
-			}
+			msg(summoner,Lang.pearlCantSummon);
+			msg("<b>Summon failed.");
 		}
 	}
 }

--- a/src/main/java/com/devotedmc/ExilePearl/command/CmdSummonConfirm.java
+++ b/src/main/java/com/devotedmc/ExilePearl/command/CmdSummonConfirm.java
@@ -1,0 +1,46 @@
+package com.devotedmc.ExilePearl.command;
+
+import org.bukkit.entity.Player;
+
+import com.devotedmc.ExilePearl.ExilePearl;
+import com.devotedmc.ExilePearl.ExilePearlApi;
+import com.devotedmc.ExilePearl.Lang;
+import com.devotedmc.ExilePearl.PearlType;
+
+public class CmdSummonConfirm extends PearlCommand {
+
+	public CmdSummonConfirm(ExilePearlApi pearlApi) {
+		super(pearlApi);
+		this.aliases.add("confirm");
+
+		this.senderMustBePlayer = true;
+		this.setHelpShort("Confirms a summon request.");
+	}
+
+	@Override
+	public void perform() {
+		if(!plugin.getPearlConfig().allowSummoning()) {
+			msg(Lang.summoningNotEnabled);
+			return;
+		}
+
+		ExilePearl pearl = plugin.getPearl(player().getUniqueId());
+		if (pearl == null || pearl.getPearlType() != PearlType.PRISON) {
+			msg(Lang.onlyPrisonedPlayers);
+			return;
+		}
+
+		Player summoner = plugin.getPearlManager().getSummoner(pearl);
+		if(summoner == null) {
+			msg(Lang.noSummonRequested);
+		} else {
+			if(plugin.summonPearl(pearl, summoner)) {
+				msg(summoner,Lang.pearlSummoned, pearl.getPlayerName());
+				msg(Lang.pearlYouWereSummoned, summoner.getName());
+			} else {
+				msg(summoner,Lang.pearlCantSummon);
+				msg("<b>Summon failed.");
+			}
+		}
+	}
+}

--- a/src/main/java/com/devotedmc/ExilePearl/config/PearlConfig.java
+++ b/src/main/java/com/devotedmc/ExilePearl/config/PearlConfig.java
@@ -152,5 +152,11 @@ public interface PearlConfig extends MySqlConfig, DocumentConfig {
 	
 	Set<RepairMaterial> getUpgradeMaterials();
 
+	/**
+	 * Gets whether summoning is enabled
+	 * @return true if summoning is enabled
+	 */
+	boolean allowSummoning();
+
 	boolean allowPearlStealing();
 }

--- a/src/main/java/com/devotedmc/ExilePearl/core/CorePearlConfig.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CorePearlConfig.java
@@ -470,6 +470,11 @@ final class CorePearlConfig implements DocumentConfig, PearlConfig {
 		
 		return upgrades;
 	}
+
+	@Override
+	public boolean allowSummoning() {
+		return doc.getBoolean("allow_summoning", true);
+	}
 	
 	@Override
 	public boolean allowPearlStealing() {

--- a/src/main/java/com/devotedmc/ExilePearl/core/CorePearlConfig.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CorePearlConfig.java
@@ -473,11 +473,11 @@ final class CorePearlConfig implements DocumentConfig, PearlConfig {
 
 	@Override
 	public boolean allowSummoning() {
-		return doc.getBoolean("allow_summoning", true);
+		return doc.getBoolean("pearls.allow_summoning", true);
 	}
 	
 	@Override
 	public boolean allowPearlStealing() {
-		return doc.getBoolean("allow_pearl_stealing", true);
+		return doc.getBoolean("pearls.allow_pearl_stealing", true);
 	}
 }

--- a/src/main/java/com/devotedmc/ExilePearl/core/CorePearlManager.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CorePearlManager.java
@@ -24,7 +24,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
 
 import com.devotedmc.ExilePearl.ExilePearl;
@@ -59,7 +58,7 @@ final class CorePearlManager implements PearlManager {
 	
 	private final Map<UUID, ExilePearl> pearls = new HashMap<UUID, ExilePearl>();
 	private final Map<UUID, ExilePearl> bcastRequests = new HashMap<UUID, ExilePearl>();
-        // Maps every summon request to the task to remove it and the summoner's UUID
+	// Maps every summon request to the task to remove it and the summoner's UUID
 	private final Map<ExilePearl,SimpleEntry<UUID, BukkitTask>> summonRequests = new HashMap<ExilePearl,SimpleEntry<UUID,BukkitTask>>();
 	
 	
@@ -394,8 +393,15 @@ final class CorePearlManager implements PearlManager {
 
 	@Override
 	public void requestSummon(Player player, ExilePearl pearl) {
-		SimpleEntry<UUID,BukkitTask> entry = new SimpleEntry<UUID,BukkitTask>(player.getUniqueId(),Bukkit.getScheduler().runTaskLaterAsynchronously(pearlApi,() -> summonRequests.remove(pearl),20L * 60L));
-		summonRequests.put(pearl,entry);
+		SimpleEntry<UUID,BukkitTask> entry = summonRequests.remove(pearl);
+		if(entry != null) {
+			// Cancel the previous removal task because
+			// it might accidentally remove *this* request instead.
+			entry.getValue().cancel();
+		}
+		// Remove this entry from the map after 60s * 20tps
+		BukkitTask timeoutReq = Bukkit.getScheduler().runTaskLaterAsynchronously(pearlApi,() -> summonRequests.remove(pearl),20L * 60L);
+		summonRequests.put(pearl,new SimpleEntry<UUID,BukkitTask>(player.getUniqueId(),timeoutReq));
 	}
 
 	@Override
@@ -404,9 +410,8 @@ final class CorePearlManager implements PearlManager {
 		if(entry == null) {
 			return null;
 		}
-                // Remove the removal task to prevent accidental double removal
-                entry.getValue().cancel();
-		// Null if offline
+		// Remove the removal task to prevent accidental double removal
+		entry.getValue().cancel();
 		return Bukkit.getPlayer(entry.getKey());
 	}
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -69,6 +69,9 @@
 # - The materials used to upgrade pearls from exile to prison
 #   The repair value is how many are required
 #
+# pearls.allow_summoning
+# - Whether or not prison pearled players can be summoned
+#
 # pearls.allow_pearl_stealing
 # - Whether or not prison pearls can be stolen by killing a summoned player
 # 
@@ -260,6 +263,7 @@ pearls:
       repair: 1
       lore:
        - This is used to upgrade exile pearls to prison pearls
+  allow_summoning: true
   allow_pearl_stealing: true
 help_item:
   enabled: true


### PR DESCRIPTION
Why is summoning even a feature tbh?

Now you can disable it to remove its abusive aspects. Pearl holders must manually travel to the end to torment their prisoners instead of summoning them if this config option is disabled.