### PR TITLE
Exile broadcast permission

### DIFF
--- a/src/main/java/com/devotedmc/ExilePearl/Lang.java
+++ b/src/main/java/com/devotedmc/ExilePearl/Lang.java
@@ -36,6 +36,7 @@ public class Lang
 
 	public static final String groupUnknown = "<i>That group doesn't exist.";
 	public static final String groupNoChatPermission = "<i>You don't have permission to chat in that group.";
+	public static final String groupNoExileBroadcastPermission = "<i>You don't have permission to broadcast in that group.";
 	public static final String groupStoppedBcasting = "<g>You've stopped broadcasting your pearl location to group <c>%s";
 	public static final String groupNowBcasting = "<g>You're now broadcasting your pearl location to group <c>%s";
 	public static final String groupPearlBroadcast = "<gray>[%s]<i>The pearl of <c>%s <i>is held by <a>%s <n>[%d %d %d %s]";

--- a/src/main/java/com/devotedmc/ExilePearl/broadcast/NLGroupBroadcastListener.java
+++ b/src/main/java/com/devotedmc/ExilePearl/broadcast/NLGroupBroadcastListener.java
@@ -2,6 +2,7 @@ package com.devotedmc.ExilePearl.broadcast;
 
 import java.util.UUID;
 
+import com.devotedmc.ExilePearl.util.NameLayerPermissions;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -11,7 +12,10 @@ import com.devotedmc.ExilePearl.Lang;
 
 import vg.civcraft.mc.civmodcore.util.Guard;
 import vg.civcraft.mc.civmodcore.util.TextUtil;
+import vg.civcraft.mc.namelayer.GroupManager;
+import vg.civcraft.mc.namelayer.NameAPI;
 import vg.civcraft.mc.namelayer.group.Group;
+import vg.civcraft.mc.namelayer.permission.PermissionType;
 
 public class NLGroupBroadcastListener implements BroadcastListener {
 
@@ -29,6 +33,10 @@ public class NLGroupBroadcastListener implements BroadcastListener {
 		String name = pearl.getHolder().getName();
 
 		String msg = TextUtil.parse(Lang.groupPearlBroadcast, group.getName(), pearl.getPlayerName(), name, l.getBlockX(), l.getBlockY(), l.getBlockZ(), l.getWorld().getName());
+
+		GroupManager gm = NameAPI.getGroupManager();
+
+		if (!gm.hasAccess(group, pearl.getPlayerId(), PermissionType.getPermission(NameLayerPermissions.ALLOW_EXILE_BROADCAST))) return;
 
 		for (UUID uid : group.getCurrentMembers()) {
 			Player p = Bukkit.getPlayer(uid);

--- a/src/main/java/com/devotedmc/ExilePearl/command/CmdPearlBroadcast.java
+++ b/src/main/java/com/devotedmc/ExilePearl/command/CmdPearlBroadcast.java
@@ -1,5 +1,6 @@
 package com.devotedmc.ExilePearl.command;
 
+import com.devotedmc.ExilePearl.util.NameLayerPermissions;
 import org.bukkit.entity.Player;
 
 import com.devotedmc.ExilePearl.ExilePearl;
@@ -47,6 +48,8 @@ public class CmdPearlBroadcast extends PearlCommand {
 			if (g != null) {
 				if (!gm.hasAccess(g, player().getUniqueId(), PermissionType.getPermission("WRITE_CHAT"))) {
 					msg(Lang.groupNoChatPermission);
+				}else if (!gm.hasAccess(g, player().getUniqueId(), PermissionType.getPermission(NameLayerPermissions.ALLOW_EXILE_BROADCAST))){
+					msg(Lang.groupNoExileBroadcastPermission);
 				}else{
 					//If they are already broadcasting to group then remove the listener for that group
 					if (pearl.isBroadcastingTo(g)) {

--- a/src/main/java/com/devotedmc/ExilePearl/core/ExilePearlCore.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/ExilePearlCore.java
@@ -196,6 +196,9 @@ final class ExilePearlCore implements ExilePearlApi {
 		} else {
 			logIgnoringHooks("CivChat");
 		}
+
+		registerExileBroadcastPermissions();
+
 		if (isBastionEnabled()) {
 			this.getServer().getPluginManager().registerEvents(bastionListener, this);
 			registerBastionPermissions();
@@ -251,6 +254,18 @@ final class ExilePearlCore implements ExilePearlApi {
 		memberAndAbove.add(GroupManager.PlayerType.OWNER);
 
 		PermissionType.registerPermission(NameLayerPermissions.BASTION_ALLOW_EXILED, memberAndAbove);
+	}
+
+	private void registerExileBroadcastPermissions() {
+		if (!this.getServer().getPluginManager().isPluginEnabled("NameLayer")) return;
+
+		LinkedList<GroupManager.PlayerType> memberAndAbove = new LinkedList<>();
+		memberAndAbove.add(GroupManager.PlayerType.MEMBERS);
+		memberAndAbove.add(GroupManager.PlayerType.MODS);
+		memberAndAbove.add(GroupManager.PlayerType.ADMINS);
+		memberAndAbove.add(GroupManager.PlayerType.OWNER);
+
+		PermissionType.registerPermission(NameLayerPermissions.ALLOW_EXILE_BROADCAST, memberAndAbove);
 	}
 
 

--- a/src/main/java/com/devotedmc/ExilePearl/util/NameLayerPermissions.java
+++ b/src/main/java/com/devotedmc/ExilePearl/util/NameLayerPermissions.java
@@ -5,5 +5,6 @@
 package com.devotedmc.ExilePearl.util;
 
 public class NameLayerPermissions {
-	public final static String  BASTION_ALLOW_EXILED = "BASTION_ALLOW_EXILED";
+	public final static String BASTION_ALLOW_EXILED = "BASTION_ALLOW_EXILED";
+	public final static String ALLOW_EXILE_BROADCAST = "ALLOW_EXILE_BROADCAST";
 }


### PR DESCRIPTION
Added the "ALLOW_EXILE_BROADCAST" permission, which is checked when attempting to start broadcasting and while already broadcasting.

If it would be preferable for me to remove the broadcast listener when they don't have permission, I can do that too.