### PR TITLE
Skip location verification in pearl decay task for block holders in u…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>vg.civcraft.mc.civmodcore</groupId>
 			<artifactId>CivModCore</artifactId>
-			<version>1.7.5</version>
+			<version>1.7.9</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/devotedmc/ExilePearl/core/CorePearlManager.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CorePearlManager.java
@@ -294,13 +294,13 @@ final class CorePearlManager implements PearlManager {
 
 			// convert timeout to milliseconds and compare against last time online.
 			if (decayTimeout == 0 || (new Date()).getTime() - pearl.getLastOnline().getTime() < (decayTimeout * 60 * 1000)) {
-				pearlApi.log("Applying decay to pearl health");
 				PearlDecayEvent e = new PearlDecayEvent(pearl, decayAmount);
 				Bukkit.getPluginManager().callEvent(e);
 				if (!e.isCancelled() && e.getDamageAmount() > 0) {
-					int newHealth = pearl.getHealth() - decayAmount;
+					int oldHealth = pearl.getHealth();
+					int newHealth = oldHealth - decayAmount;
 					pearl.setHealth(newHealth);
-					pearlApi.log("Set pearl health to %s", newHealth);
+					pearlApi.log("Set pearl health from %s to %s", oldHealth, newHealth);
 				}
 			}
 
@@ -324,7 +324,7 @@ final class CorePearlManager implements PearlManager {
 					pearlsToFree.add(pearl);
 				}
 			} else {
-				pearlApi.log("Skipping verification of block holder in unloaded chunk at %s.", holder.getLocation());
+				pearlApi.log("Skipping verification of block holder for player %s in unloaded chunk at %s.", pearl.getPlayerName(), holder.getLocation());
 			}
 		}
 

--- a/src/main/java/com/devotedmc/ExilePearl/core/CorePearlManager.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CorePearlManager.java
@@ -300,7 +300,7 @@ final class CorePearlManager implements PearlManager {
 					int oldHealth = pearl.getHealth();
 					int newHealth = oldHealth - decayAmount;
 					pearl.setHealth(newHealth);
-					pearlApi.log("Set pearl health from %s to %s", oldHealth, newHealth);
+					pearlApi.log("Set pearl for player %s health from %s to %s", pearl.getPlayerName(), oldHealth, newHealth);
 				}
 			}
 

--- a/src/main/java/com/devotedmc/ExilePearl/holder/PearlHolder.java
+++ b/src/main/java/com/devotedmc/ExilePearl/holder/PearlHolder.java
@@ -4,6 +4,7 @@ import org.bukkit.Location;
 
 import com.devotedmc.ExilePearl.ExilePearl;
 import org.bukkit.World;
+import vg.civcraft.mc.civmodcore.locations.chunkmeta.block.BlockBasedChunkMeta;
 
 import java.util.Objects;
 
@@ -51,6 +52,6 @@ public interface PearlHolder {
 			return false;
 		}
 
-		return world.isChunkLoaded(loc.getBlockX()/16, loc.getBlockZ()/16);
+		return world.isChunkLoaded(BlockBasedChunkMeta.toChunkCoord(loc.getBlockX()), BlockBasedChunkMeta.toChunkCoord(loc.getBlockZ()));
 	}
 }

--- a/src/main/java/com/devotedmc/ExilePearl/holder/PearlHolder.java
+++ b/src/main/java/com/devotedmc/ExilePearl/holder/PearlHolder.java
@@ -3,6 +3,9 @@ package com.devotedmc.ExilePearl.holder;
 import org.bukkit.Location;
 
 import com.devotedmc.ExilePearl.ExilePearl;
+import org.bukkit.World;
+
+import java.util.Objects;
 
 /**
  * Interface for an object that can hold or contain an exile pearl
@@ -35,4 +38,19 @@ public interface PearlHolder {
 	 * @return true if the holder is a block
 	 */
 	public boolean isBlock();
+
+	/**
+	 * Gets whether the holder is in a loaded chunk
+	 * @return true if the holder is in a loaded chunk
+	 */
+	public default boolean inLoadedChunk() {
+		Location loc = getLocation();
+		World world = loc.getWorld();
+
+		if (world == null) {
+			return false;
+		}
+
+		return world.isChunkLoaded(loc.getBlockX()/16, loc.getBlockZ()/16);
+	}
 }


### PR DESCRIPTION
…nloaded chunks

During the pearl decay task, location verification of block holders was [causing lag](https://timings.aikar.co/?id=ecb03b387e2a4f15a447b2c2b550e874) due to it loading chunks. This commit intends to fix that by skipping location verification for block holders in unloaded chunks. Decaying of pearl health still occurs as that is separate from location verification in the task.