### PR TITLE
Replace pearls with player heads

### DIFF
--- a/src/main/java/com/devotedmc/ExilePearl/Lang.java
+++ b/src/main/java/com/devotedmc/ExilePearl/Lang.java
@@ -27,7 +27,7 @@ public class Lang
 	public static final String pearlAlreadyBcasting = "<i>You're already broadcasting to that player.";
 	public static final String pearlSilencedBcast = "<g>You silenced broadcasts from <c>%s.";
 	public static final String pearlBroadcast = "<i>The pearl of <c>%s <i>is held by <a>%s <n>[%d %d %d %s]";
-	public static final String pearlCantThrow = "<i>You can't throw exile pearls.";
+	public static final String pearlCantPlace = "<i>You can't place exile pearls.";
 	public static final String pearlCantSummon = "<i>That pearl can't be summoned.";
 	public static final String pearlSummoned = "<g>You have summoned <c>%s<g>!";
 	public static final String pearlYouWereSummoned = "<g>You were summoned by <c>%s<g>!";

--- a/src/main/java/com/devotedmc/ExilePearl/PearlFreeReason.java
+++ b/src/main/java/com/devotedmc/ExilePearl/PearlFreeReason.java
@@ -8,7 +8,6 @@ package com.devotedmc.ExilePearl;
 public enum PearlFreeReason
 {
 	FREED_BY_PLAYER,
-	PEARL_THROWN,
 	FREED_BY_ADMIN,
 	FORCE_FREED_BY_ADMIN,
 	HEALTH_DECAY,

--- a/src/main/java/com/devotedmc/ExilePearl/config/PearlConfig.java
+++ b/src/main/java/com/devotedmc/ExilePearl/config/PearlConfig.java
@@ -76,12 +76,6 @@ public interface PearlConfig extends MySqlConfig, DocumentConfig {
 	boolean getMustPrisonPearlHotBar();
 
 	/**
-	 * Gets whether pearls can be freed by throwing them
-	 * @return true if they can be freed by throwing
-	 */
-	boolean getFreeByThrowing();
-
-	/**
 	 * Gets whether freeing a prison pearl should teleport the player
 	 * @return true if they should be teleported
 	 */

--- a/src/main/java/com/devotedmc/ExilePearl/core/CoreExilePearl.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CoreExilePearl.java
@@ -19,7 +19,7 @@ import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.util.Vector;
 
 import com.devotedmc.ExilePearl.ExilePearl;
@@ -340,8 +340,9 @@ final class CoreExilePearl implements ExilePearl {
 	@Override
 	public ItemStack createItemStack() {
 		List<String> lore = pearlApi.getLoreProvider().generateLore(this);
-		ItemStack is = new ItemStack(Material.ENDER_PEARL, 1);
-		ItemMeta im = is.getItemMeta();
+		ItemStack is = new ItemStack(Material.PLAYER_HEAD, 1);
+		SkullMeta im = (SkullMeta) is.getItemMeta();
+		im.setOwningPlayer(Bukkit.getOfflinePlayer(this.getPlayerId()));
 		im.setDisplayName(this.getPlayerName());
 		im.setLore(lore);
 		im.addEnchant(Enchantment.DURABILITY, 1, true);
@@ -364,7 +365,7 @@ final class CoreExilePearl implements ExilePearl {
 		if (pearlId == this.pearlId) {
 
 			// re-create the item stack to update the values
-			ItemMeta im = is.getItemMeta();
+			SkullMeta im = (SkullMeta) is.getItemMeta();
 			im.setLore(pearlApi.getLoreProvider().generateLore(this));
 			is.setItemMeta(im);
 			return true;

--- a/src/main/java/com/devotedmc/ExilePearl/core/CoreExilePearl.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CoreExilePearl.java
@@ -363,8 +363,10 @@ final class CoreExilePearl implements ExilePearl {
 		int pearlId = pearlApi.getLoreProvider().getPearlIdFromItemStack(is);
 
 		if (pearlId == this.pearlId) {
-
 			// re-create the item stack to update the values
+			if (!(is.getItemMeta() instanceof SkullMeta)) {
+				is = new ItemStack(Material.PLAYER_HEAD, 1);
+			}
 			SkullMeta im = (SkullMeta) is.getItemMeta();
 			im.setLore(pearlApi.getLoreProvider().generateLore(this));
 			is.setItemMeta(im);

--- a/src/main/java/com/devotedmc/ExilePearl/core/CoreLoreGenerator.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CoreLoreGenerator.java
@@ -180,7 +180,7 @@ final class CoreLoreGenerator implements LoreProvider {
 			return null;
 		}
 
-		if (!is.getType().equals(Material.ENDER_PEARL)) {
+		if (!(is.getType().equals(Material.PLAYER_HEAD) || is.getType().equals(Material.ENDER_PEARL))) {
 			return null;
 		}
 

--- a/src/main/java/com/devotedmc/ExilePearl/core/CorePearlConfig.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CorePearlConfig.java
@@ -173,11 +173,6 @@ final class CorePearlConfig implements DocumentConfig, PearlConfig {
 	}
 
 	@Override
-	public boolean getFreeByThrowing() {
-		return doc.getBoolean("pearls.free_by_throwing", false);
-	}
-
-	@Override
 	public boolean getShouldFreeTeleport() {
 		return doc.getBoolean("pearls.free_teleport", true);
 	}

--- a/src/main/java/com/devotedmc/ExilePearl/core/CorePearlManager.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CorePearlManager.java
@@ -188,7 +188,7 @@ final class CorePearlManager implements PearlManager {
 			storage.getStorage().pearlRemove(pearl);
 			if(pearl.getPearlType() == PearlType.PRISON) {
 				dropInventory(player);
-				if(pearlApi.getPearlConfig().getShouldFreeTeleport() && (reason == PearlFreeReason.FREED_BY_PLAYER || reason == PearlFreeReason.PEARL_THROWN)) {
+				if(pearlApi.getPearlConfig().getShouldFreeTeleport() && (reason == PearlFreeReason.FREED_BY_PLAYER)) {
 					player.teleport(pearl.getLocation().add(0, 0.5, 0));
 				} else {
 					SpawnUtil.spawnPlayer(player, pearlApi.getPearlConfig().getMainWorld());

--- a/src/main/java/com/devotedmc/ExilePearl/core/CorePearlManager.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CorePearlManager.java
@@ -453,7 +453,7 @@ final class CorePearlManager implements PearlManager {
 		for(int i = 0; i < inv.getSize(); i++) {
 			final ItemStack item = inv.getItem(i);
 			if(item == null) continue;
-			if(item.getType() == Material.ENDER_PEARL) continue;
+			if(item.getType() == Material.PLAYER_HEAD) continue;
 			inv.clear(i);
 			Bukkit.getScheduler().runTask(pearlApi, new Runnable() {
 

--- a/src/main/java/com/devotedmc/ExilePearl/holder/BlockHolder.java
+++ b/src/main/java/com/devotedmc/ExilePearl/holder/BlockHolder.java
@@ -1,5 +1,8 @@
 package com.devotedmc.ExilePearl.holder;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -95,7 +98,10 @@ public class BlockHolder implements PearlHolder {
 		}
 
 		// In the container inventory?
-		for (ItemStack item : inv.all(Material.ENDER_PEARL).values()) {
+		List<ItemStack> potentialPearls = new ArrayList<>();
+		potentialPearls.addAll(inv.all(Material.PLAYER_HEAD).values());
+		potentialPearls.addAll(inv.all(Material.ENDER_PEARL).values());
+		for (ItemStack item : potentialPearls) {
 			if (pearl.validateItemStack(item)) {
 				return HolderVerifyResult.IN_CHEST;
 			}
@@ -113,7 +119,11 @@ public class BlockHolder implements PearlHolder {
 					continue;
 				}
 				Inventory relInv = ((InventoryHolder)relState).getInventory();
-				for (ItemStack item : relInv.all(Material.ENDER_PEARL).values()) {
+
+				potentialPearls = new ArrayList<>();
+				potentialPearls.addAll(relInv.all(Material.PLAYER_HEAD).values());
+				potentialPearls.addAll(relInv.all(Material.ENDER_PEARL).values());
+				for (ItemStack item : potentialPearls) {
 					if (pearl.validateItemStack(item)) {
 						return HolderVerifyResult.IN_CHEST;
 					}

--- a/src/main/java/com/devotedmc/ExilePearl/holder/PlayerHolder.java
+++ b/src/main/java/com/devotedmc/ExilePearl/holder/PlayerHolder.java
@@ -62,14 +62,14 @@ public class PlayerHolder implements PearlHolder {
 		}
 
 		// In the player inventory?
-		for (ItemStack item : player.getInventory().all(Material.ENDER_PEARL).values()) {
+		for (ItemStack item : player.getInventory().all(Material.PLAYER_HEAD).values()) {
 			if (pearl.validateItemStack(item)) {
 				return HolderVerifyResult.IN_PLAYER_INVENTORY;
 			}
 		}
 
 		// In a crafting inventory?
-		for (ItemStack item : player.getOpenInventory().getTopInventory().all(Material.ENDER_PEARL).values()) {
+		for (ItemStack item : player.getOpenInventory().getTopInventory().all(Material.PLAYER_HEAD).values()) {
 			if (pearl.validateItemStack(item)) {
 				return HolderVerifyResult.IN_PLAYER_INVENTORY_VIEW;
 			}

--- a/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
+++ b/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
@@ -748,19 +748,10 @@ public class PlayerListener implements Listener, Configurable {
 		}
 
 		Player player = e.getPlayer();
-
-		if (!pearlApi.getPearlConfig().getFreeByThrowing()) {
-			msg(player, Lang.pearlCantThrow);
-			e.setCancelled(true);
-			player.getInventory().setItemInMainHand(pearl.createItemStack());
-			return;
-		}
-
+		msg(player, Lang.pearlCantPlace);
 		e.setCancelled(true);
-		if (pearlApi.freePearl(pearl, PearlFreeReason.PEARL_THROWN)) {
-			player.getInventory().setItemInMainHand(null);
-			msg(player, Lang.pearlYouFreed, pearl.getPlayerName());
-		}
+		player.getInventory().setItemInMainHand(pearl.createItemStack());
+
 	}
 
 	/**
@@ -783,7 +774,7 @@ public class PlayerListener implements Listener, Configurable {
 			return;
 		}
 
-		msg(p, Lang.pearlCantThrow);
+		msg(p, Lang.pearlCantPlace);
 		e.setCancelled(true);
 
 		// Need to schedule this or else the re-created pearl doesn't show up

--- a/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
+++ b/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
@@ -163,7 +163,8 @@ public class PlayerListener implements Listener, Configurable {
 			return null;
 		}
 
-		if ((item.getType() == Material.PLAYER_HEAD || item.getType() == Material.ENDER_PEARL) && item.getEnchantmentLevel(Enchantment.DURABILITY) != 0) {
+		if ((item.getType() == Material.PLAYER_HEAD || item.getType() == Material.ENDER_PEARL)
+				&& item.getEnchantmentLevel(Enchantment.DURABILITY) != 0) {
 			ExilePearl pearl = pearlApi.getPearlFromItemStack(item);
 			if (pearl == null || pearl.getFreedOffline()) {
 				return new ItemStack(Material.ENDER_PEARL, 1);

--- a/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
+++ b/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
@@ -141,7 +141,10 @@ public class PlayerListener implements Listener, Configurable {
 	@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled = true)
 	public void onInventoryOpen(InventoryOpenEvent e) {
 		Inventory inv = e.getInventory();
-		for (Entry<Integer, ? extends ItemStack> entry : inv.all(Material.ENDER_PEARL).entrySet()) {
+		HashMap<Integer, ItemStack> potentialPearls = new HashMap<>();
+		potentialPearls.putAll(inv.all(Material.ENDER_PEARL));
+		potentialPearls.putAll(inv.all(Material.PLAYER_HEAD));
+		for (Entry<Integer, ? extends ItemStack> entry : potentialPearls.entrySet()) {
 			ItemStack newitem = validatePearl(entry.getValue());
 			if (newitem != null) {
 				inv.setItem(entry.getKey(), newitem);
@@ -160,7 +163,7 @@ public class PlayerListener implements Listener, Configurable {
 			return null;
 		}
 
-		if (item.getType() == Material.ENDER_PEARL && item.getEnchantmentLevel(Enchantment.DURABILITY) != 0) {
+		if ((item.getType() == Material.PLAYER_HEAD || item.getType() == Material.ENDER_PEARL) && item.getEnchantmentLevel(Enchantment.DURABILITY) != 0) {
 			ExilePearl pearl = pearlApi.getPearlFromItemStack(item);
 			if (pearl == null || pearl.getFreedOffline()) {
 				return new ItemStack(Material.ENDER_PEARL, 1);
@@ -218,7 +221,7 @@ public class PlayerListener implements Listener, Configurable {
 		World world = imprisoner.getWorld();
 		Inventory inv = imprisoner.getInventory();
 		for (Entry<Integer, ? extends ItemStack> entry :
-			inv.all(Material.ENDER_PEARL).entrySet()) {
+			inv.all(Material.PLAYER_HEAD).entrySet()) {
 			ItemStack item = entry.getValue();
 			ExilePearl pearl = pearlApi.getPearlFromItemStack(item);
 			if (pearl == null) {
@@ -900,7 +903,7 @@ public class PlayerListener implements Listener, Configurable {
 		}
 
 		// Get the pearl item being crafted
-		ItemStack pearlItem = inv.getItem(inv.first(Material.ENDER_PEARL));
+		ItemStack pearlItem = inv.getItem(inv.first(Material.PLAYER_HEAD));
 
 		if (pearlItem == null) {
 			inv.setResult(new ItemStack(Material.AIR));
@@ -1002,7 +1005,7 @@ public class PlayerListener implements Listener, Configurable {
 
 			// Changing the value of the crafting items results in a dupe glitch so any remaining
 			// materials need to be placed back into the player's inventory.
-			inv.remove(Material.ENDER_PEARL);
+			inv.remove(Material.PLAYER_HEAD);
 			if (repairMatsAvailable > repairMatsToUse) {
 				for (int i = 0; i < inv.getContents().length; i++) {
 					ItemStack is = inv.getItem(i);
@@ -1050,7 +1053,7 @@ public class PlayerListener implements Listener, Configurable {
 			int upgradeMatsRequired = upgradeItem.getRepairAmount();
 			int upgradeMatsAvailable = invItems.getAmount(upgradeItem.getStack());
 			if(upgradeMatsAvailable < upgradeMatsRequired) return;
-			inv.remove(Material.ENDER_PEARL);
+			inv.remove(Material.PLAYER_HEAD);
 			if(upgradeMatsAvailable > upgradeMatsRequired) {
 				for(int i = 0; i < inv.getContents().length; i++) {
 					ItemStack is = inv.getItem(i);
@@ -1110,7 +1113,7 @@ public class PlayerListener implements Listener, Configurable {
 			for(Set<RepairMaterial> set : repairMaterials.values()) {
 				for(RepairMaterial mat : set) {
 					ShapelessRecipe r1 = new ShapelessRecipe(new NamespacedKey(pearlApi, "repairPearl"), resultItem);
-					r1.addIngredient(1, Material.ENDER_PEARL);
+					r1.addIngredient(1, Material.PLAYER_HEAD);
 					r1.addIngredient(1, mat.getStack().getData());
 
 					Bukkit.getServer().addRecipe(r1);
@@ -1132,7 +1135,7 @@ public class PlayerListener implements Listener, Configurable {
 
 			for(RepairMaterial mat : upgradeMaterials) {
 				ShapelessRecipe r1 = new ShapelessRecipe(new NamespacedKey(pearlApi, "upgradePearl"),resultItem);
-				r1.addIngredient(1, Material.ENDER_PEARL);
+				r1.addIngredient(1, Material.PLAYER_HEAD);
 				r1.addIngredient(1, mat.getStack().getData());
 
 				Bukkit.getServer().addRecipe(r1);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -40,9 +40,6 @@
 #  - When true, pearls that are outside world-border will be freed during a 
 #    decay operation
 # 
-# pearls.free_by_throwing
-#  - When true, pearls can be freed by throwing them
-# 
 # pearls.free_teleport
 #  - When true, freeing a prison pearled player teleports them to the freer
 # 
@@ -258,7 +255,6 @@ general:
   max_pearled_message: 'You have too many imprisoned alts'
 pearls:
   autofree_worldborder: true
-  free_by_throwing: false
   free_teleport: true
   hotbar_needed: true
   decay_interval_human: week


### PR DESCRIPTION
 (#51) *Sadly player heads do not glow... https://bugs.mojang.com/browse/MC-100947*

# Changes
- removed references to `pearls.free_by_throwing`
- changed all references to lored exile pearls into lored player heads, except in four cases where both PLAYER_HEAD's and ENDER_PEARL's are checked for the purposes of migration:
	- CoreLoreGenerator::getValidLore
	- BlockHolder::holderVerifyResult 
	- PlayerListener::onInventoryOpen
	- PlayerListener::validatePearl

I tested migrating pearls, decaying pearls, repairing pearls, and `/ep` commands. Everything appeared to work -- though with so many small changes I still may have broken something painstakingly obvious :/.