### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/main/java/com/devotedmc/ExilePearl/ExilePearl.java
+++ b/src/main/java/com/devotedmc/ExilePearl/ExilePearl.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import org.bukkit.Location;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -95,6 +96,12 @@ public interface ExilePearl {
 	 * @param item The new pearl item
 	 */
 	void setHolder(Item item);
+
+	/**
+	 * Sets the pearl holder to an entity
+	 * @param entity The new pearl entity
+	 */
+	void setHolder(Entity entity);
 
     /**
      * Gets the pearl health value

--- a/src/main/java/com/devotedmc/ExilePearl/core/CoreExilePearl.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CoreExilePearl.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
+import com.devotedmc.ExilePearl.holder.EntityHolder;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.bukkit.Bukkit;
@@ -15,6 +16,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
@@ -179,13 +181,17 @@ final class CoreExilePearl implements ExilePearl {
 		setHolderInternal(new BlockHolder(block));
 	}
 
+	@Override
+	public void setHolder(Entity entity) {
+		Guard.ArgumentNotNull(entity, "entity");
+		setHolderInternal(new EntityHolder(entity));
+	}
 
 	@Override
 	public void setHolder(Item item) {
 		Guard.ArgumentNotNull(item, "item");
 		setHolderInternal(new ItemHolder(item));
 	}
-
 
 	/**
 	 * Internal method for updating the holder

--- a/src/main/java/com/devotedmc/ExilePearl/holder/BlockHolder.java
+++ b/src/main/java/com/devotedmc/ExilePearl/holder/BlockHolder.java
@@ -3,10 +3,13 @@ package com.devotedmc.ExilePearl.holder;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Nameable;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
+import org.bukkit.block.Container;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
@@ -15,6 +18,7 @@ import org.bukkit.inventory.ItemStack;
 import com.devotedmc.ExilePearl.ExilePearl;
 
 import vg.civcraft.mc.civmodcore.api.BlockAPI;
+import vg.civcraft.mc.civmodcore.api.ItemNames;
 import vg.civcraft.mc.civmodcore.util.Guard;
 
 /**
@@ -38,36 +42,14 @@ public class BlockHolder implements PearlHolder {
 
 	@Override
 	public String getName() {
-		switch (block.getType()) {
-		case CHEST:
-		case TRAPPED_CHEST:
-		case ENDER_CHEST:
-			return "a chest";
-
-		case FURNACE:
-			return "a furnace";
-
-		case BREWING_STAND:
-			return "a brewing stand";
-
-		case DISPENSER:
-			return "a dispenser";
-
-		case ITEM_FRAME:
-			return "a wall frame";
-
-		case DROPPER:
-			return "a dropper";
-
-		case HOPPER:
-			return "a hopper";
-
-		case ENCHANTING_TABLE:
-			return "an enchantment table";
-
-		default:
-			return "a block";
+		String customNameString = "";
+		if (block.getState() instanceof Nameable) {
+			String customName = ((Container) block.getState()).getCustomName();
+			if (customName != null) {
+				customNameString = String.format(" %scalled %s", ChatColor.RESET, customName);
+			}
 		}
+		return String.format("a %s%s", ItemNames.getItemName(block.getType()), customNameString);
 	}
 
 	@Override

--- a/src/main/java/com/devotedmc/ExilePearl/holder/EntityHolder.java
+++ b/src/main/java/com/devotedmc/ExilePearl/holder/EntityHolder.java
@@ -1,0 +1,68 @@
+package com.devotedmc.ExilePearl.holder;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.ItemFrame;
+
+import com.devotedmc.ExilePearl.ExilePearl;
+
+import vg.civcraft.mc.civmodcore.util.Guard;
+
+/**
+ * An entity holding an exile pearl
+ */
+public class EntityHolder implements PearlHolder {
+
+	private final Entity entity;
+
+	/**
+	 * Creates a new EntityHolder instance
+	 * @param entity The entity holding the pearl
+	 */
+	public EntityHolder(final Entity entity) {
+		Guard.ArgumentNotNull(entity, "entity");
+		this.entity = entity;
+	}
+
+	@Override
+	public String getName() {
+		switch (entity.getType()) {
+			case ITEM_FRAME:
+				return "an item frame";
+			default:
+				return "an entity";
+		}
+	}
+
+	@Override
+	public Location getLocation() {
+		return entity.getLocation();
+	}
+
+	@Override
+	public HolderVerifyResult validate(final ExilePearl pearl) {
+		if (entity instanceof ItemFrame) {
+			if (pearl.validateItemStack(((ItemFrame) entity).getItem())) {
+				return  HolderVerifyResult.IN_ITEM_FRAME;
+			}
+		}
+		return HolderVerifyResult.DEFAULT;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		EntityHolder other = (EntityHolder) o;
+		return entity.equals(other.entity);
+	}
+
+	@Override
+	public boolean isBlock() {
+		return true;
+	}
+}

--- a/src/main/java/com/devotedmc/ExilePearl/holder/EntityHolder.java
+++ b/src/main/java/com/devotedmc/ExilePearl/holder/EntityHolder.java
@@ -43,7 +43,7 @@ public class EntityHolder implements PearlHolder {
 	public HolderVerifyResult validate(final ExilePearl pearl) {
 		if (entity instanceof ItemFrame) {
 			if (pearl.validateItemStack(((ItemFrame) entity).getItem())) {
-				return  HolderVerifyResult.IN_ITEM_FRAME;
+				return HolderVerifyResult.IN_ITEM_FRAME;
 			}
 		}
 		return HolderVerifyResult.DEFAULT;

--- a/src/main/java/com/devotedmc/ExilePearl/holder/HolderVerifyResult.java
+++ b/src/main/java/com/devotedmc/ExilePearl/holder/HolderVerifyResult.java
@@ -21,7 +21,8 @@ public enum HolderVerifyResult
 	IN_PLAYER_INVENTORY("in player inventory", true),
 	IN_PLAYER_INVENTORY_VIEW("in player inventory view", true),
 	IN_VIEWER_HAND("in viewer hand", true),
-	CREATVE_MODE("creative mode", true);
+	CREATIVE_MODE("creative mode", true),
+	IN_ITEM_FRAME("in item frame", true);
 
 	private final String text;
 	private final boolean isValid;

--- a/src/main/java/com/devotedmc/ExilePearl/holder/PlayerHolder.java
+++ b/src/main/java/com/devotedmc/ExilePearl/holder/PlayerHolder.java
@@ -1,5 +1,6 @@
 package com.devotedmc.ExilePearl.holder;
 
+import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -31,7 +32,7 @@ public class PlayerHolder implements PearlHolder {
 
 	@Override
 	public String getName() {
-		return player.getName();
+		return ChatColor.AQUA + player.getName();
 	}
 
 	@Override

--- a/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
+++ b/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
@@ -343,7 +343,7 @@ public class PlayerListener implements Listener, Configurable {
 	 * @param holder The pearl holder
 	 * @param event The event
 	 */
-	private void  updatePearlHolder(ExilePearl pearl, InventoryHolder holder, Cancellable event) {
+	private void updatePearlHolder(ExilePearl pearl, InventoryHolder holder, Cancellable event) {
 
 		if (holder instanceof Chest) {
 			updatePearl(pearl, (Chest)holder);
@@ -510,6 +510,7 @@ public class PlayerListener implements Listener, Configurable {
 
 				// ShiftClicking into a furnace will not move the pearl into the furnace so the pearlHolder should not be updated
 				if (event.getClick().isShiftClick() && holder != null && holder.getInventory() instanceof FurnaceInventory) {
+					event.setCancelled(true);
 					return;
 				}
 


### PR DESCRIPTION
1) `BlockHolder::getname()` : Fixes #62. Returns the block type for any block [and the blocks custom display name](https://i.imgur.com/VXNYD0x.png) (if applicable).
2) `PlayerHolder::getName()` : Show PlayerHolder name in aqua for a bit more clarity.
3) `EntityHolder` : Allow storing pearls in itemframes. Behavior before this commit was that pearls can be placed in item frames yet no PearlMovedEvent is triggered and the pearl is freed upon validation attempt. 
4) Fixes a bug where shift clicking into a furnace updates the pearl holder to the furnace even though the pearl is not actually transferred.