### PR TITLE
Upgrade and Downgrade Pearls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Exile pearls can also be upgraded to prison pearls, which imprison the pearled p
     /ep help                      Displays plugin help
     /ep locate                    Locates your pearl location
     /ep free                      Frees a pearl in your hand
+    /ep upgrade                   Upgrades an Exile Pearl to a Prison Pearl
+    /ep downgrade                 Downgrades a Prison Pearl
     /ep summon                    Requests to summon the player in the pearl in your hand
     /ep confirm                   Confirms a summon request
     /ep broadcast                 Broadcasts your pearl's location to a group or player

--- a/src/main/java/com/devotedmc/ExilePearl/command/CmdDowngrade.java
+++ b/src/main/java/com/devotedmc/ExilePearl/command/CmdDowngrade.java
@@ -1,0 +1,46 @@
+package com.devotedmc.ExilePearl.command;
+
+import com.devotedmc.ExilePearl.ExilePearl;
+import com.devotedmc.ExilePearl.ExilePearlApi;
+import com.devotedmc.ExilePearl.Lang;
+import com.devotedmc.ExilePearl.PearlType;
+import com.devotedmc.ExilePearl.util.SpawnUtil;
+
+/**
+ * Downgrades the Prison Pearl in senders main hand
+ */
+public class CmdDowngrade extends PearlCommand {
+
+	public CmdDowngrade(ExilePearlApi pearlApi) {
+		super(pearlApi);
+		this.aliases.add("downgrade");
+		this.helpShort = "Downgrades a Prison Pearl";
+		this.senderMustBePlayer = true;
+	}
+
+	@Override
+	public void perform() {
+		ExilePearl pearl = plugin.getPearlFromItemStack(player().getInventory().getItemInMainHand());
+		if (pearl == null) {
+			msg(Lang.pearlMustBeHoldingPearl);
+			return;
+		}
+		if (pearl.getPearlType() != PearlType.PRISON) {
+			msg("<i>Y This type of pearl cannot be downgraded");
+			return;
+		}
+		downgradePearl(pearl);
+
+	}
+
+	public void downgradePearl(ExilePearl pearl) {
+		pearl.setPearlType(PearlType.EXILE);
+		if (pearl.getPlayer() != null && pearl.getPlayer().isOnline()) {
+			SpawnUtil.spawnPlayer(pearl.getPlayer(), pearl.getPearlType() == PearlType.PRISON ? plugin.getPearlConfig().getPrisonWorld() : plugin.getPearlConfig().getMainWorld());
+			msg(pearl.getPlayer(), "<i>Your pearl has been downgraded by %s.", player().getDisplayName());
+		}
+		String feedback = "The pearl for player %s was downgraded to an Exile Pearl.";
+		plugin.log(feedback, pearl.getPlayerName());
+		msg(feedback, pearl.getPlayerName());
+	}
+}

--- a/src/main/java/com/devotedmc/ExilePearl/command/CmdDowngrade.java
+++ b/src/main/java/com/devotedmc/ExilePearl/command/CmdDowngrade.java
@@ -30,7 +30,6 @@ public class CmdDowngrade extends PearlCommand {
 			return;
 		}
 		downgradePearl(pearl);
-
 	}
 
 	public void downgradePearl(ExilePearl pearl) {

--- a/src/main/java/com/devotedmc/ExilePearl/command/CmdExilePearl.java
+++ b/src/main/java/com/devotedmc/ExilePearl/command/CmdExilePearl.java
@@ -15,6 +15,7 @@ public class CmdExilePearl extends PearlCommand {
 	public final PearlCommand cmdBcast;
 	public final PearlCommand cmdBcastConfirm;
 	public final PearlCommand cmdBcastSilence;
+	public final PearlCommand cmdDowngrade;
 
 	public CmdExilePearl(ExilePearlApi pearlApi) {
 		super(pearlApi);
@@ -28,6 +29,7 @@ public class CmdExilePearl extends PearlCommand {
 		cmdBcast = new CmdPearlBroadcast(plugin);
 		cmdBcastConfirm = new CmdPearlBroadcastAccept(plugin);
 		cmdBcastSilence = new CmdPearlBroadcastSilence(plugin);
+		cmdDowngrade = new CmdDowngrade(plugin);
 
 		addSubCommand(plugin.getAutoHelp());
 
@@ -36,9 +38,11 @@ public class CmdExilePearl extends PearlCommand {
 		addSubCommand(cmdBcast);
 		addSubCommand(cmdBcastConfirm);
 		addSubCommand(cmdBcastSilence);
+		addSubCommand(cmdDowngrade);
 		addSubCommand(new CmdSummon(plugin));
 		addSubCommand(new CmdReturn(plugin));
 		addSubCommand(new CmdSummonConfirm(plugin));
+		addSubCommand(new CmdUpgrade(plugin));
 
 		// Admin commands
 		addSubCommand(new CmdConfig(plugin));

--- a/src/main/java/com/devotedmc/ExilePearl/command/CmdUpgrade.java
+++ b/src/main/java/com/devotedmc/ExilePearl/command/CmdUpgrade.java
@@ -1,0 +1,63 @@
+package com.devotedmc.ExilePearl.command;
+
+import com.devotedmc.ExilePearl.ExilePearl;
+import com.devotedmc.ExilePearl.ExilePearlApi;
+import com.devotedmc.ExilePearl.Lang;
+import com.devotedmc.ExilePearl.PearlType;
+import com.devotedmc.ExilePearl.RepairMaterial;
+import com.devotedmc.ExilePearl.util.SpawnUtil;
+import vg.civcraft.mc.civmodcore.itemHandling.ItemMap;
+
+import java.util.Set;
+
+
+/**
+ * Upgrades the Exile Pearl in senders main hand to a Prison Pearl using upgrade_material held in players inventory
+ */
+public class CmdUpgrade extends PearlCommand {
+
+	public CmdUpgrade(ExilePearlApi pearlApi) {
+		super(pearlApi);
+		this.aliases.add("upgrade");
+		this.helpShort = "Upgrades an Exile Pearl to a Prison Pearl";
+		this.senderMustBePlayer = true;
+	}
+
+	@Override
+	public void perform() {
+		ExilePearl pearl = plugin.getPearlFromItemStack(player().getInventory().getItemInMainHand());
+		if(pearl == null) {
+			msg(Lang.pearlMustBeHoldingPearl);
+			return;
+		}
+		Set<RepairMaterial> upgradeMaterials = plugin.getPearlConfig().getUpgradeMaterials();
+		if(pearl.getPearlType() != PearlType.EXILE || upgradeMaterials == null) {
+			msg("<i>This type of pearl is not upgradable!");
+			return;
+		}
+		ItemMap inv = new ItemMap(player().getInventory());
+		for (RepairMaterial rm : upgradeMaterials) {
+			if (inv.getAmount(rm.getStack()) >= rm.getRepairAmount()) {
+				rm.getStack().setAmount(rm.getRepairAmount());
+				ItemMap matches = new ItemMap(rm.getStack());
+				boolean removed = new ItemMap(matches.getItemStackRepresentation()).removeSafelyFrom(player().getInventory());
+				if (removed) {
+					upgradePearl(pearl);
+					return;
+				}
+			}
+		}
+		msg("<b>You lack the materials to upgrade this pearl");
+	}
+
+	public void upgradePearl(ExilePearl pearl) {
+		pearl.setPearlType(PearlType.PRISON);
+		if (pearl.getPlayer() != null && pearl.getPlayer().isOnline()) {
+			SpawnUtil.spawnPlayer(pearl.getPlayer(), pearl.getPearlType() == PearlType.PRISON ? plugin.getPearlConfig().getPrisonWorld() : plugin.getPearlConfig().getMainWorld());
+			msg(pearl.getPlayer(), "<i>You've been imprisoned in the end by %s.", player().getDisplayName());
+		}
+		String feedback = "The pearl for player %s was upgraded to a Prison Pearl.";
+		plugin.log(feedback, pearl.getPlayerName());
+		msg(feedback, pearl.getPlayerName());
+	}
+}

--- a/src/main/java/com/devotedmc/ExilePearl/core/CoreLoreGenerator.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CoreLoreGenerator.java
@@ -117,6 +117,9 @@ final class CoreLoreGenerator implements LoreProvider {
 			if (cmd != null) {
 				lore.add(parse("<l>Commands:"));
 				lore.add(parse(CmdExilePearl.instance().cmdFree.getUsageTemplate(true)));
+				if(pearl.getPearlType() == PearlType.PRISON) {
+					lore.add(parse(CmdExilePearl.instance().cmdDowngrade.getUsageTemplate(true)));
+				}
 			}
 		}
 		return lore;


### PR DESCRIPTION
_Fixes #49, #52_ 

I chose to add a command instead of fixing the configs upgrade recipe because : 
1) I don't think it makes sense to have an intermediate material, with only a single use case, which is used right after its creation.
2) It seemed inconsistent to keep upgrading as a recipe and make downgrading, which should not have to require a material, a command

There are some Exile Pearl quirks I have not touched in this PR. For example, `upgrade_materials` is actually a set of RepairMaterial's, which means the `repair` field of an upgrade material is actually its cost to upgrade.