### PR TITLE
Resolve #33

### DIFF
--- a/src/main/java/com/devotedmc/ExilePearl/PearlAccess.java
+++ b/src/main/java/com/devotedmc/ExilePearl/PearlAccess.java
@@ -166,4 +166,13 @@ public interface PearlAccess {
 	 * @return Count of exiled alts
 	 */
 	int getExiledAlts(UUID player, boolean includeSelf);
+
+	/**
+	 * Gets the primary account/pearl a player is pearled on. If banstick isn't enabled then it will simply return null.
+	 * @param player UUID of the player to fetch a primary pearl for
+	 * @return The primary pearl of whatever account they are linked to, if multiple whichever one comes first.
+	 * Note: Will ALSO return null if there is no pearled accounts linked to the alt.
+	 * TODO Make an alternative method that returns a list of all pearled accounts that a player is linked to.
+	 */
+	ExilePearl getPrimaryPearl(UUID player);
 }

--- a/src/main/java/com/devotedmc/ExilePearl/core/CorePearlManager.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CorePearlManager.java
@@ -491,4 +491,32 @@ final class CorePearlManager implements PearlManager {
         }
         return 0;
 	}
+
+	@Override
+	public ExilePearl getPrimaryPearl(UUID player) {
+		if(pearlApi.isBanStickEnabled()) {
+			BSPlayer bsPlayer = BSPlayer.byUUID(player);
+			//If BSPlayer is invalid, we would be unable to find what alts are linked anyway.
+			//So we just make an attempt to see if the player logging in themself is a pearled player.
+			if(bsPlayer == null) {
+				if(isPlayerExiled(player)) {
+					return pearlApi.getPearl(player);
+				}
+				return null;
+			}
+			//So we cycle through alts until we find a pearl.
+			for(BSPlayer alt : bsPlayer.getTransitiveSharedPlayers(true)) {
+				ExilePearl primPearl = pearlApi.getPearl(alt.getUUID());
+				if(primPearl != null) {
+					if(!alt.getUUID().equals(bsPlayer.getUUID())) {
+						return primPearl;
+					}
+				}
+			}
+		}
+
+		//Banstick isn't enabled, return null since we cannot see associated accounts.
+		//If Banstick is enabled, the player is not pearled.
+		return null;
+	}
 }

--- a/src/main/java/com/devotedmc/ExilePearl/core/ExilePearlCore.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/ExilePearlCore.java
@@ -723,4 +723,9 @@ final class ExilePearlCore implements ExilePearlApi {
 	public int getExiledAlts(UUID player, boolean includeSelf) {
 		return pearlManager.getExiledAlts(player, includeSelf);
 	}
+
+	@Override
+	public ExilePearl getPrimaryPearl(UUID player) {
+		return pearlManager.getPrimaryPearl(player);
+	}
 }

--- a/src/main/java/com/devotedmc/ExilePearl/listener/BanStickListener.java
+++ b/src/main/java/com/devotedmc/ExilePearl/listener/BanStickListener.java
@@ -30,6 +30,11 @@ public class BanStickListener extends RuleListener {
             return;
         }
         if (pearlApi.getExiledAlts(e.getUniqueId(), false) >= config.maxAltsPearled()) {
+        	if(pearlApi.getPrimaryPearl(e.getUniqueId()).getFreedOffline()) {
+        		//Player is not actually pearled, but technically awaiting pearl logon.
+				//therefore we simply return.
+        		return;
+			}
             e.setLoginResult(Result.KICK_OTHER);
             e.setKickMessage(config.altBanMessage());
         }

--- a/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
+++ b/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
@@ -117,6 +117,19 @@ public class PlayerListener implements Listener, Configurable {
 		this.pearlApi = pearlApi;
 	}
 
+	/**
+	 * Informs a player about pearling after they've been pearled.
+	 * @param event
+	 */
+	@EventHandler
+	public void PlayerPearledListener(PlayerPearledEvent event) {
+		event.getPearl().getPlayer().sendMessage(ChatColor.GOLD + "You've been pearled. Pearling is how " +
+				"players imprison others in order to exact justice, or revenge against each other. " +
+				"Your captors can be raiders, or even militia members of a nearby town. " +
+				"The only way to be freed, is to be freed by your captor, or have a friend break you out. " +
+				"Try using " + ChatColor.AQUA + "/ep locate " + ChatColor.GOLD + "to see who you are held by, or where you are held.");
+	}
+
 
 	/**
 	 * Announce the person in a pearl when a player holds it


### PR DESCRIPTION
This fixes PR #33.

I should note, the older commit on Aug 13th 2020 was reverted when i fixed the merge errors. It shouldn't be included in the commit now as shown by the added files.

Essentially I just added a method to fetch a pearl if there is one keeping a player pearled, that way we can run a check to see if the pearl was freed offline. Took a little longer than I expected but that's fine.