### PR TITLE
Use peristent data container for exile pearl IDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.devotedmc</groupId>
 	<artifactId>ExilePearl</artifactId>
 	<packaging>jar</packaging>
-	<version>1.4.3</version>
+	<version>1.4.4</version>
 	<name>ExilePearl</name>
 	<url>https://github.com/Civclassic/ExilePearl</url>
 	
@@ -79,7 +79,7 @@
 		<dependency>
 			<groupId>com.programmerdan.minecraft</groupId>
 			<artifactId>banstick</artifactId>
-			<version>1.2.2</version>
+			<version>1.2.3</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/com/devotedmc/ExilePearl/LoreProvider.java
+++ b/src/main/java/com/devotedmc/ExilePearl/LoreProvider.java
@@ -2,6 +2,7 @@ package com.devotedmc.ExilePearl;
 
 import java.util.List;
 import java.util.UUID;
+import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 
 public interface LoreProvider {
@@ -44,4 +45,9 @@ public interface LoreProvider {
 	 * @return The returned lore
 	 */
 	List<String> generatePearlInfo(ExilePearl pearl);
+
+	/**
+	 * Retrieve the exile pearl ID key used for storing the pearl ID on a PersistentDataContainer.
+	 */
+	NamespacedKey getExilePearlIdKey();
 }

--- a/src/main/java/com/devotedmc/ExilePearl/config/PearlConfig.java
+++ b/src/main/java/com/devotedmc/ExilePearl/config/PearlConfig.java
@@ -193,7 +193,7 @@ public interface PearlConfig extends MySqlConfig, DocumentConfig {
 	/**
 	 * Gets whether people should be allowed to deploy an elytra with a pearl in their inventory
 	 * Also determines if they should be able to pick up pearl items while gliding
-	 * @return true if they should be able to fly & pick up exile pearls while gliding
+	 * @return true if they should be able to fly and pick up exile pearls while gliding
 	 */
 	boolean canElytraWithPearls();
 }

--- a/src/main/java/com/devotedmc/ExilePearl/core/CoreExilePearl.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CoreExilePearl.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
@@ -34,6 +35,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.util.Vector;
 import vg.civcraft.mc.civmodcore.util.TextUtil;
 
@@ -349,6 +352,10 @@ final class CoreExilePearl implements ExilePearl {
 		im.setLore(lore);
 		im.addEnchant(Enchantment.DURABILITY, 1, true);
 		im.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+
+		PersistentDataContainer container = im.getPersistentDataContainer();
+		container.set(pearlApi.getLoreProvider().getExilePearlIdKey(), PersistentDataType.INTEGER, this.pearlId);
+
 		is.setItemMeta(im);
 		return is;
 	}
@@ -367,6 +374,14 @@ final class CoreExilePearl implements ExilePearl {
 		if (pearlId == this.pearlId) {
 			ItemMeta im = is.getItemMeta();
 			im.setLore(pearlApi.getLoreProvider().generateLore(this));
+
+			PersistentDataContainer container = im.getPersistentDataContainer();
+
+			NamespacedKey exilePearlIdKey = pearlApi.getLoreProvider().getExilePearlIdKey();
+			if (!container.has(exilePearlIdKey, PersistentDataType.INTEGER)) {
+				container.set(exilePearlIdKey, PersistentDataType.INTEGER, this.pearlId);
+			}
+
 			is.setItemMeta(im);
 			return true;
 		}

--- a/src/main/java/com/devotedmc/ExilePearl/core/CorePluginFactory.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CorePluginFactory.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
@@ -136,7 +137,7 @@ public final class CorePluginFactory implements PearlFactory {
 	}
 
 	public LoreProvider createLoreGenerator() {
-		return new CoreLoreGenerator(pearlApi.getPearlConfig());
+		return new CoreLoreGenerator(pearlApi.getPearlConfig(), new NamespacedKey(pearlApi, "exile_pearl_id"));
 	}
 
 	public PearlConfig createPearlConfig() {

--- a/src/main/java/com/devotedmc/ExilePearl/core/PearlDecayTask.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/PearlDecayTask.java
@@ -46,7 +46,10 @@ final class PearlDecayTask extends ExilePearlTask {
 			return;
 		}
 
+		long start = System.currentTimeMillis();
 		pearlApi.getPearlManager().decayPearls();
+		long duration = System.currentTimeMillis() - start;
+		pearlApi.log("Pearl decay task took %dms", duration);
 	}
 
 	@Override


### PR DESCRIPTION
This should significantly speed up the pearl decay task, as the item lore does not need to be parsed.